### PR TITLE
[Enh]: Spotter Category - Items View

### DIFF
--- a/src/GToolkit-Spotter-Extensions/GtSpotterCategory.extension.st
+++ b/src/GToolkit-Spotter-Extensions/GtSpotterCategory.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #GtSpotterCategory }
 
 { #category : #'*GToolkit-Spotter-Extensions' }
-GtSpotterCategory >> gtItemsFor: aSearch [
+GtSpotterCategory >> gtSearchItemsFor: aSearch [
 	<gtSearch>
 	^ aSearch list
 		title: search title;
@@ -19,4 +19,16 @@ GtSpotterCategory >> gtSpotterActDefaultFrom: aSpotterElement [
 	^ GtInspector
 		openOn: self items
 		from: aSpotterElement
+]
+
+{ #category : #'*GToolkit-Spotter-Extensions' }
+GtSpotterCategory >> gtViewItemsFor: aView [
+	<gtView>
+
+	^ aView forward
+		title: 'Items';
+		priority: 5;
+		object: self items;
+		view: #gtLiveFor:;
+		actionUpdateButton
 ]


### PR DESCRIPTION
In an inspector Spotter, clicking on the category spawns the category, but there are no suitable user-oriented views.

Before fix:

https://github.com/feenkcom/gtoolkit-spotter/assets/184176/013f32ec-bae5-4ba6-b2cd-8e8bfa8859f9

After fix:

https://github.com/feenkcom/gtoolkit-spotter/assets/184176/6fe76776-4af2-497b-87aa-4e0f0597b176


